### PR TITLE
Several of the links were broken on the homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: U.S. 2020 Election API Resource Center
 description: This is a toolbox of API collections, visualizations, and tooling to help make sense of the 2020 election in the United States. Providing a single landing page, documentation, and Postman collections that can be easily run using the Postman platform.
 image: https://postman-toolboxes2.s3.amazonaws.com/assets/us-2020-election/postman-town-2020-election-750.png
-url: https://postman-toolboxes2.github.io/us-2020-elections
+url: https://postman-toolboxes.github.io/us-2020-elections
 email: covid-19@postman.com
 
 github_user: postman-toolboxes

--- a/_data/apis.yaml
+++ b/_data/apis.yaml
@@ -34,7 +34,7 @@ apis:
     x-data:
       rating: 8
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/12
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/12
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -57,7 +57,7 @@ apis:
     x-data:
       rating: 5
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/4
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/4
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -104,7 +104,7 @@ apis:
         - name: American National Election Studies
           url: https://electionstudies.org/
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/13
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/13
   contact:
   - FN: MTNA
     email: mtna@mtna.us
@@ -127,7 +127,7 @@ apis:
     x-data:
       rating: 5
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/5
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/5
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -151,7 +151,7 @@ apis:
     x-data:
       rating: 5
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/6
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/6
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -189,7 +189,7 @@ apis:
     x-data:
       rating: 8
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/7
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/7
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -212,7 +212,7 @@ apis:
     x-data:
       rating: 3
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/8
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/8
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -234,7 +234,7 @@ apis:
     x-data:
       rating: 5
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/9
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/9
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -260,7 +260,7 @@ apis:
     x-data:
       rating: 4
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/10
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/10
   contact:
   - FN: Postman
     email: covid-19@postman.com
@@ -284,7 +284,7 @@ apis:
     x-data:
       rating: 8
   - type: x-github-issue
-    url: https://github.com/postman-toolboxes2/us-2020-elections/issues/14
+    url: https://github.com/postman-toolboxes/us-2020-elections/issues/14
   contact:
   - FN: Postman
     email: covid-19@postman.com


### PR DESCRIPTION
Looks like a quick find replace was done for the s3 bucket and it broke all references to the GitHub repo. 